### PR TITLE
Removed allowing unverified certificates

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,6 @@
         "@frontity/tiny-router": "^1.4.4",
         "@frontity/wp-source": "^1.11.7",
         "@radioaktywne/ra-theme": "./packages/ra-theme",
-        "cross-env": "^7.0.3",
         "frontity": "^1.17.2",
         "html-react-parser": "^3.0.4",
         "react-player": "^2.11.0",
@@ -4648,23 +4647,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -17065,14 +17047,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
-    },
-    "cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "requires": {
-        "cross-spawn": "^7.0.1"
-      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "build": "frontity build",
-    "serve": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 frontity serve",
-    "dev": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 frontity dev",
+    "serve": "frontity serve",
+    "dev": "frontity dev",
     "update": "ncu -u && npm i",
     "format": "prettier --write ."
   },
@@ -20,7 +20,6 @@
     "@radioaktywne/ra-theme": "./packages/ra-theme",
     "@frontity/tiny-router": "^1.4.4",
     "@frontity/wp-source": "^1.11.7",
-    "cross-env": "^7.0.3",
     "frontity": "^1.17.2",
     "html-react-parser": "^3.0.4",
     "react-player": "^2.11.0",

--- a/web/server.js
+++ b/web/server.js
@@ -3,8 +3,6 @@ const http = require("http");
 
 const server = http.createServer(frontity);
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-
 const port = process.env.WEB_PORT || 3000;
 
 server.listen(port);


### PR DESCRIPTION
It's not really that necessary right now. There is really no security risk in enabling it as the requests from `web` container to `wordpress` container don't reach the public internet, but it's ugly.

In the future, I will probably make it possible to pass a custom self-signed certificate for Node to trust so we can test `https` locally.